### PR TITLE
fixing faulty return statement

### DIFF
--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -61,6 +61,7 @@
 
         if (handler.shortcuts && (action = handler.shortcuts[def.raw])) {
           handler.send(action, event);
+          event.preventDefault();
           return;
         }
       }

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -138,7 +138,7 @@
 
   function targetIsNotInput(event) {
     var tagName = event.target.tagName;
-    return !(tagName === 'INPUT' || tagName === 'SELECT' || tagName === 'TEXTAREA');
+    return !(tagName === 'INPUT') && !(tagName === 'SELECT') && !(tagName === 'TEXTAREA');
   }
 
   Ember.Shortcuts = Ember.Object.extend({

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -175,8 +175,15 @@
   Ember.Route.reopen({
     mergedProperties: ['shortcuts'],
     registerShortcuts: function() {
-      if (this.shortcuts) register(Ember.keys(this.shortcuts));
-    }.on('init')
+      if (!$.isEmptyObject(this.shortcuts)) {
+        this.clearShortcuts();
+        register(Ember.keys(this.shortcuts));
+      }
+    }.on('init'),
+
+    clearShortcuts: function() {
+      SHORTCUTS = {};
+    },
   });
 
   Ember.onLoad('Ember.Application', function(Application) {

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -138,7 +138,7 @@
 
   function targetIsNotInput(event) {
     var tagName = event.target.tagName;
-    return tagName !== 'INPUT' || tagName !== 'SELECT' || tagName !== 'TEXTAREA';
+    return !(tagName === 'INPUT' || tagName === 'SELECT' || tagName === 'TEXTAREA');
   }
 
   Ember.Shortcuts = Ember.Object.extend({

--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -174,13 +174,14 @@
 
   Ember.Route.reopen({
     mergedProperties: ['shortcuts'],
-    registerShortcuts: function() {
-      if (!$.isEmptyObject(this.shortcuts)) {
-        this.clearShortcuts();
+    activate: function() {
+      if (Object.keys(this.shortcuts).length > 0) {
         register(Ember.keys(this.shortcuts));
       }
-    }.on('init'),
-
+    },
+    deactivate: function() {
+      this.clearShortcuts();
+    },
     clearShortcuts: function() {
       SHORTCUTS = {};
     },


### PR DESCRIPTION
Using the existing line of code, the return statement would return true if the tagName is an input because the other two bools return true, making it all true. I amended the boolean to evaluate the line as a whole instead of individual parts.