### PR TITLE
fixed input detection logic

### DIFF
--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -138,7 +138,7 @@
 
   function targetIsNotInput(event) {
     var tagName = event.target.tagName;
-    return tagName !== 'INPUT' || tagName !== 'SELECT' || tagName !== 'TEXTAREA';
+    return !tagName.match( /INPUT|SELECT|TEXTAREA/ );
   }
 
   Ember.Shortcuts = Ember.Object.extend({


### PR DESCRIPTION
previous implementations was wrong. It always evaluates to `true`