### PR TITLE
Register addon with Ember libraries

### DIFF
--- a/ember-shortcuts.js
+++ b/ember-shortcuts.js
@@ -207,4 +207,6 @@
       }
     });
   });
+
+  Ember.libraries.register('Ember Shortcuts', '0.0.8');
 }(Ember, Ember.$));


### PR DESCRIPTION
I've recently updated to Ember 2.x and I found out very useful the libraries and their versions displayed in the console. In my opinion, it will be great to add *Ember Shortcuts* to the Ember Libraries like this

![screenshot from 2016-02-17 11-11-44](https://cloud.githubusercontent.com/assets/1711687/13111975/9f258046-d567-11e5-980f-527c1f3f8326.png)
